### PR TITLE
RSS-ECOMM-3_02: Display Prices with and Without Discount for Discounted Products

### DIFF
--- a/src/components/ui/catalog/view/view.ts
+++ b/src/components/ui/catalog/view/view.ts
@@ -143,11 +143,14 @@ export default class ViewCatalog {
     basePrice.innerText = `${product.masterData.current.masterVariant.prices?.[0].value.centAmount
       .toString()
       .slice(0, -2)} RUB`;
-    const discountedPrice: HTMLElement = new Builder('span', '', Blocks.catalog, 'card', 'disc-price').element();
-    discountedPrice.innerText = `${product.masterData.current.masterVariant.prices?.[1].value.centAmount
-      .toString()
-      .slice(0, -2)} RUB`;
-    priceTag.append(basePrice, discountedPrice);
+    priceTag.append(basePrice);
+    if (product.masterData.current.masterVariant.prices?.[0].discounted) {
+      const discountedPrice: HTMLElement = new Builder('span', '', Blocks.catalog, 'card', 'disc-price').element();
+      discountedPrice.innerText = `${product.masterData.current.masterVariant.prices?.[0].discounted.value.centAmount
+        .toString()
+        .slice(0, -2)} RUB`;
+      priceTag.append(discountedPrice);
+    }
     card.append(cardPic, nameTag, descriptionTag, readMore, priceTag);
     card.setAttribute('id', (product.key || '0').split('-')[1]);
     return card;

--- a/src/sass/components/_catalog.scss
+++ b/src/sass/components/_catalog.scss
@@ -41,18 +41,37 @@
     text-align: center;
     padding: 3px 10px;
     font-size: 1.5rem;
-    line-height: 1.5;
+    line-height: 1.2;
     font-weight: bold;
-    min-height: 75px;
+    min-height: 60px;
   }
 
   &__card_description-tag {
-    height: 60px;
+    height: 30px;
     overflow: hidden;
     line-height: 1.45;
   }
 
-  &__card_read-more {
+  &__read-more {
     text-align: center;
+    color: #3f3f3f;
+    font-size: 1.2rem;
+    margin: 0 auto;
+    font-weight: bold;
+  }
+
+  &__card_price-tag {
+    line-height: 1;
+  }
+
+  &__card_base-price {
+    text-decoration-line: line-through;
+    font-size: 1.4rem;
+  }
+
+  &__card_disc-price {
+    color: #880000;
+    margin-left: 5px;
+    font-size: 1.8rem;
   }
 }


### PR DESCRIPTION
1. Task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_02.md)
2. Screenshot: 
![image](https://github.com/HellCAT0147/eCommerce-Application/assets/111487491/863113e2-4687-4b3d-ac89-00cc3b4c00b2)
3. Deploy: see the Netlify bot section below ↓
4. Done 01.09.2023 / deadline 05.09.2023
5. Score: 20/20
✅ Acceptance Criteria
Both the original price and the discounted price are clearly displayed for discounted products.
The discounted price is visually distinct and clearly indicates that it is the current price the customer needs to pay.
If the original price is displayed, it should be marked in a way that clearly communicates that it is not the current price (e.g., strikethrough).
