### PR TITLE
Get Cart Items Quantity

### DIFF
--- a/src/components/api/e-commerce-api.ts
+++ b/src/components/api/e-commerce-api.ts
@@ -765,4 +765,16 @@ export default class ECommerceApi {
       return this.errorObjectOrThrow(error);
     }
   }
+
+  public async getCartItemsQuantity(isOnlyUnique: boolean = false): Promise<number | ErrorObject> {
+    try {
+      const responseActiveCart: Cart | ErrorObject = await this.getActiveCart();
+      if ('code' in responseActiveCart && 'message' in responseActiveCart) return responseActiveCart;
+
+      if (isOnlyUnique) return responseActiveCart.lineItems.length || 0;
+      return responseActiveCart.totalLineItemQuantity || 0;
+    } catch (error) {
+      return this.errorObjectOrThrow(error);
+    }
+  }
 }


### PR DESCRIPTION
1. Task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_23.md)
2. Screenshot: -
3. Deploy: see the Netlify bot section below ↓
4. Done 13.09.2023 / deadline 19.09.2023
5. Score: 5 / 5

Call getCartItemsQuantity to get amount of items in cart of all products, for example: if cart has 2 dresses and 1 blouse, this method return 3. If you need to get only amount of specific items kind - call this method with optional parameter isOnlyUnique - true.
