### PR TITLE
Modify Cart Item Quantity

### DIFF
--- a/src/components/api/e-commerce-api.ts
+++ b/src/components/api/e-commerce-api.ts
@@ -793,7 +793,7 @@ export default class ECommerceApi {
     }
   }
 
-  public async removeCartItem(id: string): Promise<Cart | ErrorObject> {
+  public async removeCartItem(id: string, isDecrease: boolean = false): Promise<Cart | ErrorObject> {
     try {
       const response: Cart | ErrorObject = await this.getActiveCart();
       if ('code' in response && 'message' in response) return response;
@@ -812,12 +812,18 @@ export default class ECommerceApi {
 
       const cartId: string = response.id;
       const cartVersion: number = response.version;
-      const actions: CartUpdateAction[] = [
-        {
+      const actions: CartUpdateAction[] = [];
+      if (isDecrease)
+        actions.push({
           action: 'removeLineItem',
           lineItemId,
-        },
-      ];
+          quantity: 1,
+        });
+      else
+        actions.push({
+          action: 'removeLineItem',
+          lineItemId,
+        });
 
       return await this.modifyCart(cartId, cartVersion, actions);
     } catch (error) {


### PR DESCRIPTION
1. Task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_11.md), [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_08.md)
2. Screenshot: -
3. Deploy: see the Netlify bot section below ↓
4. Done 13.09.2023 / deadline 19.09.2023
5. Score: 15 / 15

Call **setCartItemQuantity** to change the quantity of a certain item in the cart. If such an item is not in the cart, a corresponding error of type ErrorObject will be returned, and it will also be returned when server-side problems occur.

Call **removeCartItem** to delete the entire string with the item. The error handling with an undiscovered item works the same way as in the previous method ↑. If this method is called with the optional second parameter isDecrease: true, it will not delete the whole item row (**if the quantity of this item >1**), but will reduce the quantity of this item by 1.

Also call **addNewProduct** to not only add a new item to the cart list, but also to increase the quantity of that item by 1.